### PR TITLE
camelize schema directives

### DIFF
--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -257,6 +257,11 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
   end
 
   defp directives(directives, type_definitions) do
+    directives =
+      Enum.map(directives, fn directive ->
+        %{directive | name: Absinthe.Utils.camelize(directive.name, lower: true)}
+      end)
+
     concat(Enum.map(directives, &render(&1, type_definitions)))
   end
 

--- a/test/absinthe/schema/type_system_directive_test.exs
+++ b/test/absinthe/schema/type_system_directive_test.exs
@@ -33,6 +33,10 @@ defmodule Absinthe.Schema.TypeSystemDirectiveTest do
         :input_field_definition
       ]
     end
+
+    directive :camel_case_me do
+      on [:field_definition]
+    end
   end
 
   defmodule TypeSystemDirectivesSdlSchema do
@@ -110,7 +114,7 @@ defmodule Absinthe.Schema.TypeSystemDirectiveTest do
         directive :feature, name: ":field_definition"
       end
 
-      field :sweet, :sweet_scalar
+      field :sweet, :sweet_scalar, directives: [:camel_case_me]
       field :which, :category
       field :pet, :dog
 
@@ -190,7 +194,7 @@ defmodule Absinthe.Schema.TypeSystemDirectiveTest do
 
   type RootQueryType {
     post: Post @feature(name: \":field_definition\")
-    sweet: SweetScalar
+    sweet: SweetScalar @camelCaseMe
     which: Category
     pet: Dog
     search(filter: SearchFilter @feature(name: \":argument_definition\")): SearchResult @feature(name: \":argument_definition\")


### PR DESCRIPTION
Pulling in changes from my upstream Absinthe PR https://github.com/absinthe-graphql/absinthe/pull/1303 so I can ship a custom schema directive that's correctly camelCased in the sdl output. Hopefully they'll do a release soon and we can pull these changes in from there.