### PR TITLE
[GRAPH-954] update absinthe fork to include optional run docset callback

### DIFF
--- a/lib/absinthe/subscription/pubsub.ex
+++ b/lib/absinthe/subscription/pubsub.ex
@@ -73,4 +73,12 @@ defmodule Absinthe.Subscription.Pubsub do
   only.
   """
   @callback publish_subscription(topic :: binary, data :: map) :: term
+
+  # @doc """
+  # This function is called by publish_mutation and is responsible for resolving the documents
+  # and publishing the results to the appropriate topics.
+  # """
+  @callback run_docset(pubsub :: t, docs_and_topics :: list, mutation_result :: term) :: term
+
+  @optional_callbacks run_docset: 3
 end


### PR DESCRIPTION
### [GRAPH-954](https://frame-io.atlassian.net/browse/GRAPH-954)

### What

Add the ability to implement an optional `run_docset` callback for the `Absinthe.Subscription.PubSub` behavior

### Why

This will allow us to manage subscription document resolution in massdriver.

[GRAPH-954]: https://frame-io.atlassian.net/browse/GRAPH-954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ