### PR TITLE
Middleware Telemetry Events.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /deps
 /doc
 /.elixir_ls
+/.elixir-tools
 erl_crash.dump
 *.ez
 src/*.erl

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -235,7 +235,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
   defp reduce_resolution(%{middleware: [middleware | remaining_middleware]} = res) do
     start_id = :erlang.unique_integer()
-    metadata = %{id: start_id, telemetry_span_context: start_id, middelware: middleware, resolution: res}
+    metadata = %{id: start_id, telemetry_span_context: start_id, middleware: middleware, resolution: res}
     :telemetry.execute(@middleware_start, %{system_time: System.system_time()}, metadata)
 
     res =
@@ -245,7 +245,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
       end
 
     stop_id = :erlang.unique_integer()
-    metadata = %{id: stop_id, telemetry_span_context: stop_id, middelware: middleware, resolution: res}
+    metadata = %{id: stop_id, telemetry_span_context: stop_id, middleware: middleware, resolution: res}
     :telemetry.execute(@middleware_stop, %{system_time: System.system_time()}, metadata)
 
     res

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -234,8 +234,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp reduce_resolution(%{middleware: []} = res), do: res
 
   defp reduce_resolution(%{middleware: [middleware | remaining_middleware]} = res) do
-    id = :erlang.unique_integer()
-    metadata = %{id: id, telemetry_span_context: id, middleware: middleware, resolution: res}
+    metadata = %{middleware: middleware, resolution: res}
     :telemetry.execute(@middleware_start, %{system_time: System.system_time()}, metadata)
 
     res =

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -6,9 +6,6 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   # Blueprint results are placed under `blueprint.result.execution`. This is
   # because the results form basically a new tree from the original blueprint.
 
-  @middleware_start [:absinthe, :middleware, :call, :start]
-  @middleware_stop [:absinthe, :middleware, :call, :stop]
-
   alias Absinthe.{Blueprint, Type, Phase}
   alias Blueprint.{Result, Execution}
 
@@ -234,17 +231,15 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp reduce_resolution(%{middleware: []} = res), do: res
 
   defp reduce_resolution(%{middleware: [middleware | remaining_middleware]} = res) do
-    metadata = %{middleware: middleware, resolution: res}
-    :telemetry.execute(@middleware_start, %{system_time: System.system_time()}, metadata)
+    :telemetry.span [:absinthe, :middleware, :call], %{middleware: middleware, resolution: res}, fn ->
+      result =
+        case call_middleware(middleware, %{res | middleware: remaining_middleware}) do
+          %{state: :suspended} = res -> res
+          res -> reduce_resolution(res)
+        end
 
-    res =
-      case call_middleware(middleware, %{res | middleware: remaining_middleware}) do
-        %{state: :suspended} = res -> res
-        res -> reduce_resolution(res)
-      end
-
-    :telemetry.execute(@middleware_stop, %{system_time: System.system_time()}, metadata)
-    res
+      {result, %{middewlare: middleware, resolution: res}}
+    end
   end
 
   defp call_middleware({{mod, fun}, opts}, res) do

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -234,8 +234,8 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp reduce_resolution(%{middleware: []} = res), do: res
 
   defp reduce_resolution(%{middleware: [middleware | remaining_middleware]} = res) do
-    start_id = :erlang.unique_integer()
-    metadata = %{id: start_id, telemetry_span_context: start_id, middleware: middleware, resolution: res}
+    id = :erlang.unique_integer()
+    metadata = %{id: id, telemetry_span_context: id, middleware: middleware, resolution: res}
     :telemetry.execute(@middleware_start, %{system_time: System.system_time()}, metadata)
 
     res =
@@ -244,10 +244,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
         res -> reduce_resolution(res)
       end
 
-    stop_id = :erlang.unique_integer()
-    metadata = %{id: stop_id, telemetry_span_context: stop_id, middleware: middleware, resolution: res}
     :telemetry.execute(@middleware_stop, %{system_time: System.system_time()}, metadata)
-
     res
   end
 

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -238,7 +238,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
           res -> reduce_resolution(res)
         end
 
-      {result, %{middewlare: middleware, resolution: res}}
+      {result, %{middleware: middleware, resolution: res}}
     end
   end
 

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -14,9 +14,6 @@ defmodule Absinthe.Pipeline do
 
   alias Absinthe.Phase
 
-  # @phase_start [:absinthe, :phase, :run, :start]
-  # @phase_stop [:absinthe, :phase, :run, :stop]
-
   @type data_t :: any
 
   @type phase_config_t :: Phase.t() | {Phase.t(), Keyword.t()}

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -414,12 +414,10 @@ defmodule Absinthe.Pipeline do
         run_phase(todo, result, [phase | done])
 
       {:ok, result} ->
-        start_id = :erlang.unique_integer()
-        metadata = %{id: start_id, telemetry_span_context: start_id, phase: phase, options: options}
+        id = :erlang.unique_integer()
+        metadata = %{id: id, telemetry_span_context: id, phase: phase, options: options}
         :telemetry.execute(@phase_start, %{system_time: System.system_time()}, metadata)
         result = run_phase(todo, result, [phase | done])
-        start_id = :erlang.unique_integer()
-        metadata = %{id: start_id, telemetry_span_context: start_id, phase: phase, options: options}
         :telemetry.execute(@phase_stop, %{system_time: System.system_time()}, metadata)
         result
 

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -414,8 +414,7 @@ defmodule Absinthe.Pipeline do
         run_phase(todo, result, [phase | done])
 
       {:ok, result} ->
-        id = :erlang.unique_integer()
-        metadata = %{id: id, telemetry_span_context: id, phase: phase, options: options}
+        metadata = %{phase: phase, options: options}
         :telemetry.execute(@phase_start, %{system_time: System.system_time()}, metadata)
         result = run_phase(todo, result, [phase | done])
         :telemetry.execute(@phase_stop, %{system_time: System.system_time()}, metadata)

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -14,8 +14,8 @@ defmodule Absinthe.Pipeline do
 
   alias Absinthe.Phase
 
-  @phase_start [:absinthe, :phase, :run, :start]
-  @phase_stop [:absinthe, :phase, :run, :stop]
+  # @phase_start [:absinthe, :phase, :run, :start]
+  # @phase_stop [:absinthe, :phase, :run, :stop]
 
   @type data_t :: any
 
@@ -414,11 +414,7 @@ defmodule Absinthe.Pipeline do
         run_phase(todo, result, [phase | done])
 
       {:ok, result} ->
-        metadata = %{phase: phase, options: options}
-        :telemetry.execute(@phase_start, %{system_time: System.system_time()}, metadata)
-        result = run_phase(todo, result, [phase | done])
-        :telemetry.execute(@phase_stop, %{system_time: System.system_time()}, metadata)
-        result
+        run_phase(todo, result, [phase | done])
 
       {:jump, result, destination_phase} when is_atom(destination_phase) ->
         run_phase(from(todo, destination_phase), result, [phase | done])


### PR DESCRIPTION
Did not add tests because `&Absinthe.TestTelemetryHelper.send_to_pid/4` is broken.  We should probably consider reconnecting our fork so we can get upstream changes again.