### PR TITLE
[GRAPH-1087] add telemetry phase for config errors and fix test

### DIFF
--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -231,15 +231,19 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp reduce_resolution(%{middleware: []} = res), do: res
 
   defp reduce_resolution(%{middleware: [middleware | remaining_middleware]} = res) do
-    :telemetry.span [:absinthe, :middleware, :call], %{middleware: middleware, resolution: res}, fn ->
-      result =
-        case call_middleware(middleware, %{res | middleware: remaining_middleware}) do
-          %{state: :suspended} = res -> res
-          res -> reduce_resolution(res)
-        end
+    :telemetry.span(
+      [:absinthe, :middleware, :call],
+      %{middleware: middleware, resolution: res},
+      fn ->
+        result =
+          case call_middleware(middleware, %{res | middleware: remaining_middleware}) do
+            %{state: :suspended} = res -> res
+            res -> reduce_resolution(res)
+          end
 
-      {result, %{middleware: middleware, resolution: res}}
-    end
+        {result, %{middleware: middleware, resolution: res}}
+      end
+    )
   end
 
   defp call_middleware({{mod, fun}, opts}, res) do

--- a/lib/absinthe/phase/subscription/subscribe_self.ex
+++ b/lib/absinthe/phase/subscription/subscribe_self.ex
@@ -27,17 +27,19 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
 
       Absinthe.Subscription.subscribe(pubsub, field_keys, subscription_id, blueprint)
 
-      {:replace, blueprint,
-       [
-         {Phase.Subscription.Result, topic: subscription_id},
-         {Phase.Telemetry, Keyword.put(options, :event, [:execute, :operation, :stop])}
-       ]}
+      pipeline = [
+        {Phase.Subscription.Result, topic: subscription_id},
+        {Phase.Telemetry, Keyword.put(options, :event, [:execute, :operation, :stop])}
+      ]
+
+      {:replace, blueprint, pipeline}
     else
       {:error, error} ->
         blueprint = update_in(blueprint.execution.validation_errors, &[error | &1])
 
         error_pipeline = [
-          {Phase.Document.Result, options}
+          {Phase.Document.Result, options},
+          {Phase.Telemetry, Keyword.put(options, :event, [:execute, :operation, :stop])}
         ]
 
         {:replace, blueprint, error_pipeline}

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -705,7 +705,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     assert System.convert_time_unit(measurements[:system_time], :native, :millisecond)
 
-    assert_receive {[:absinthe, :execute, :operation, :stop], measurements, %{id: ^id}, _config}
+    assert_receive {[:absinthe, :execute, :operation, :stop], _measurements, %{id: ^id}, _config}
 
     Absinthe.Subscription.publish(PubSub, "foo", thing: client_id)
     assert_receive({:broadcast, msg})

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -687,7 +687,9 @@ defmodule Absinthe.Execution.SubscriptionTest do
         [:absinthe, :subscription, :publish, :start],
         [:absinthe, :subscription, :publish, :stop]
       ],
-      &Absinthe.TestTelemetryHelper.send_to_pid/4,
+      fn event, measurements, metadata, config ->
+        send(self(), {event, measurements, metadata, config})
+      end,
       %{}
     )
 
@@ -699,13 +701,11 @@ defmodule Absinthe.Execution.SubscriptionTest do
                context: %{pubsub: PubSub}
              )
 
-    assert_receive {:telemetry_event,
-                    {[:absinthe, :execute, :operation, :start], measurements, %{id: id}, _config}}
+    assert_receive {[:absinthe, :execute, :operation, :start], measurements, %{id: id}, _config}
 
     assert System.convert_time_unit(measurements[:system_time], :native, :millisecond)
 
-    assert_receive {:telemetry_event,
-                    {[:absinthe, :execute, :operation, :stop], _, %{id: ^id}, _config}}
+    assert_receive {[:absinthe, :execute, :operation, :stop], measurements, %{id: ^id}, _config}
 
     Absinthe.Subscription.publish(PubSub, "foo", thing: client_id)
     assert_receive({:broadcast, msg})
@@ -717,11 +717,8 @@ defmodule Absinthe.Execution.SubscriptionTest do
            } == msg
 
     # Subscription events
-    assert_receive {:telemetry_event,
-                    {[:absinthe, :subscription, :publish, :start], _, %{id: id}, _config}}
-
-    assert_receive {:telemetry_event,
-                    {[:absinthe, :subscription, :publish, :stop], _, %{id: ^id}, _config}}
+    assert_receive {[:absinthe, :subscription, :publish, :start], _, %{id: id}, _config}
+    assert_receive {[:absinthe, :subscription, :publish, :stop], _, %{id: ^id}, _config}
 
     :telemetry.detach(context.test)
   end


### PR DESCRIPTION
## GRAPH-1087

### What I'm doing
- Adding the telemetry phase to the subscription pipeline in the case of config errors.
- Removing some test code from upstream that snuck into our fork.  

### Why?
No telemetry event was being fired when subscription config errored, so we were missing mucho telemetry.

### Testing & Deployment strategy 
- Tests pass