### PR TITLE
[REL-114] Execute local subscription dispatch synchronously

### DIFF
--- a/lib/absinthe/subscription/proxy.ex
+++ b/lib/absinthe/subscription/proxy.ex
@@ -44,11 +44,11 @@ defmodule Absinthe.Subscription.Proxy do
     # bottleneck execution inside each proxy process
 
     unless payload.node == state.pubsub.node_name() do
-      Task.Supervisor.start_child(state.task_super, Subscription.Local, :publish_mutation, [
+      Subscription.Local.publish_mutation(
         state.pubsub,
         payload.mutation_result,
         payload.subscribed_fields
-      ])
+      )
     end
 
     {:noreply, state}


### PR DESCRIPTION
Execute local subscription dispatch synchronously. 

There's a lot more work that needs doing, this is just a short-term emergency fix to reign in the unbounded concurrency.