### PR TITLE
[GRAPH-1102] Customizable doc storage with default implementation

### DIFF
--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -13,6 +13,12 @@ handler function to any of the following event names:
 - `[:absinthe, :resolve, :field, :stop]` when field resolution finishes
 - `[:absinthe, :middleware, :batch, :start]` when the batch processing starts
 - `[:absinthe, :middleware, :batch, :stop]` when the batch processing finishes
+- `[:absinthe, :subscription, :storage, :put, :start]` when document subscription storage starts
+- `[:absinthe, :subscription, :storage, :put, :stop]` when document subscription storage finishes
+- `[:absinthe, :subscription, :storage, :delete, :start]` when document subscription storage deletion starts
+- `[:absinthe, :subscription, :storage, :delete, :stop]` when document subscription storage deletion finishes
+- `[:absinthe, :subscription, :storage, :get_docs_by_field_key, :start]` when document subscription storage retrieval starts
+- `[:absinthe, :subscription, :storage, :get_docs_by_field_key, :stop]` when document subscription storage retrieval finishes
 
 Telemetry handlers are called with `measurements` and `metadata`. For details on
 what is passed, checkout `Absinthe.Phase.Telemetry`, `Absinthe.Middleware.Telemetry`,

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -159,18 +159,13 @@ defmodule Absinthe.Subscription do
     Module.concat([pubsub, :Registry])
   end
 
-  @doc false
-  def document_storage_name(pubsub) do
-    Module.concat([pubsub, :Storage])
-  end
-
-  def document_storage(pubsub) do
-    {:ok, document_storage} =
+  def storage_module(pubsub) do
+    {:ok, storage} =
       pubsub
       |> registry_name
-      |> Registry.meta(:document_storage)
+      |> Registry.meta(:storage)
 
-    document_storage
+    storage
   end
 
   @doc false

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -150,17 +150,13 @@ defmodule Absinthe.Subscription do
 
     storage_module = document_storage(pubsub)
     storage_process_name = document_storage_name(pubsub)
-
-    storage_module.put(storage_process_name, doc_id, doc_value)
-    storage_module.subscribe(storage_process_name, doc_id, field_keys)
+    storage_module.put(storage_process_name, doc_id, doc_value, field_keys)
   end
 
   @doc false
   def unsubscribe(pubsub, doc_id) do
     storage_module = document_storage(pubsub)
     storage_process_name = document_storage_name(pubsub)
-
-    storage_module.unsubscribe(storage_process_name, doc_id)
     storage_module.delete(storage_process_name, doc_id)
   end
 

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -30,7 +30,7 @@ defmodule Absinthe.Subscription do
 
   alias __MODULE__
 
-  alias Absinthe.Subscription.PipelineSerializer
+  alias Absinthe.Subscription.DocumentStorage
 
   @doc """
   Add Absinthe.Subscription to your process tree.
@@ -141,37 +141,17 @@ defmodule Absinthe.Subscription do
 
   @doc false
   def subscribe(pubsub, field_keys, doc_id, doc) do
-    field_keys = List.wrap(field_keys)
-
-    doc_value = %{
-      initial_phases: PipelineSerializer.pack(doc.initial_phases),
-      source: doc.source
-    }
-
-    storage_module = document_storage(pubsub)
-    storage_process_name = document_storage_name(pubsub)
-    storage_module.put(storage_process_name, doc_id, doc_value, field_keys)
+    DocumentStorage.put(pubsub, doc_id, doc, field_keys)
   end
 
   @doc false
   def unsubscribe(pubsub, doc_id) do
-    storage_module = document_storage(pubsub)
-    storage_process_name = document_storage_name(pubsub)
-    storage_module.delete(storage_process_name, doc_id)
+    DocumentStorage.delete(pubsub, doc_id)
   end
 
   @doc false
   def get(pubsub, key) do
-    storage_module = document_storage(pubsub)
-    storage_process_name = document_storage_name(pubsub)
-
-    storage_process_name
-    |> storage_module.get_docs_by_field_key(key)
-    |> Enum.map(fn {doc_id, %{initial_phases: initial_phases} = doc} ->
-      initial_phases = PipelineSerializer.unpack(initial_phases)
-      {doc_id, Map.put(doc, :initial_phases, initial_phases)}
-    end)
-    |> Map.new()
+    DocumentStorage.get_docs_by_field_key(pubsub, key)
   end
 
   @doc false

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -151,10 +151,9 @@ defmodule Absinthe.Subscription do
     storage_module = storage_implementation(pubsub)
 
     :telemetry.span(
-      [:absinthe, :subscription, :storage, :subscribe],
+      [:absinthe, :subscription, :document, :subscribe],
       %{
         doc_id: doc_id,
-        doc: doc,
         field_keys: field_keys,
         storage_module: storage_module
       },
@@ -166,7 +165,6 @@ defmodule Absinthe.Subscription do
         {result,
          %{
            doc_id: doc_id,
-           doc: doc,
            field_keys: field_keys,
            storage_module: storage_module
          }}
@@ -179,7 +177,7 @@ defmodule Absinthe.Subscription do
     storage_module = storage_implementation(pubsub)
 
     :telemetry.span(
-      [:absinthe, :subscription, :storage, :unsubscribe],
+      [:absinthe, :subscription, :document, :unsubscribe],
       %{
         doc_id: doc_id,
         storage_module: storage_module
@@ -203,9 +201,9 @@ defmodule Absinthe.Subscription do
     storage_module = storage_implementation(pubsub)
 
     :telemetry.span(
-      [:absinthe, :subscription, :storage, :get],
+      [:absinthe, :subscription, :document, :get],
       %{
-        key: key,
+        field_key: key,
         storage_module: storage_module
       },
       fn ->
@@ -222,7 +220,7 @@ defmodule Absinthe.Subscription do
 
         {result,
          %{
-           key: key,
+           field_key: key,
            storage_module: storage_module
          }}
       end

--- a/lib/absinthe/subscription/default_document_storage.ex
+++ b/lib/absinthe/subscription/default_document_storage.ex
@@ -3,12 +3,12 @@ defmodule Absinthe.Subscription.DefaultDocumentStorage do
 
   @moduledoc """
   Default document storage for Absinthe. Stores subscription
-  documents and field keys in a Registry process
+  documents and field keys in a Registry process.
   """
 
   @impl Absinthe.Subscription.DocumentStorage
   def child_spec(opts) do
-    {Registry, opts}
+    Registry.child_spec(opts)
   end
 
   @impl Absinthe.Subscription.DocumentStorage

--- a/lib/absinthe/subscription/default_document_storage.ex
+++ b/lib/absinthe/subscription/default_document_storage.ex
@@ -1,0 +1,70 @@
+defmodule Absinthe.Subscription.DefaultDocumentStorage do
+  @behaviour Absinthe.Subscription.DocumentStorage
+
+  @moduledoc """
+  Default document storage for Absinthe. Stores subscription
+  documents and field keys in a Registry process
+  """
+
+  @impl Absinthe.Subscription.DocumentStorage
+  def child_spec(opts) do
+    {Registry, opts}
+  end
+
+  @impl Absinthe.Subscription.DocumentStorage
+  def subscribe(pubsub, doc_id, doc_value, field_keys) do
+    storage = Absinthe.Subscription.storage_name(pubsub)
+
+    pdict_add_fields(doc_id, field_keys)
+
+    for field_key <- field_keys do
+      {:ok, _} = Registry.register(storage, field_key, doc_id)
+    end
+
+    {:ok, _} = Registry.register(storage, doc_id, doc_value)
+  end
+
+  @impl Absinthe.Subscription.DocumentStorage
+  def unsubscribe(pubsub, doc_id) do
+    storage = Absinthe.Subscription.storage_name(pubsub)
+
+    for field_key <- pdict_fields(doc_id) do
+      Registry.unregister(storage, field_key)
+    end
+
+    Registry.unregister(storage, doc_id)
+
+    pdict_delete_fields(doc_id)
+    :ok
+  end
+
+  @impl Absinthe.Subscription.DocumentStorage
+  def get_docs_by_field_key(pubsub, field_key) do
+    storage = Absinthe.Subscription.storage_name(pubsub)
+
+    storage
+    |> Registry.lookup(field_key)
+    |> MapSet.new(fn {_pid, doc_id} -> doc_id end)
+    |> Enum.reduce(%{}, fn doc_id, acc ->
+      case Registry.lookup(storage, doc_id) do
+        [] ->
+          acc
+
+        [{_pid, doc} | _rest] ->
+          Map.put_new(acc, doc_id, doc)
+      end
+    end)
+  end
+
+  defp pdict_fields(doc_id) do
+    Process.get({__MODULE__, doc_id}, [])
+  end
+
+  defp pdict_add_fields(doc_id, field_keys) do
+    Process.put({__MODULE__, doc_id}, field_keys ++ pdict_fields(doc_id))
+  end
+
+  defp pdict_delete_fields(doc_id) do
+    Process.delete({__MODULE__, doc_id})
+  end
+end

--- a/lib/absinthe/subscription/default_document_storage.ex
+++ b/lib/absinthe/subscription/default_document_storage.ex
@@ -1,47 +1,49 @@
 defmodule Absinthe.Subscription.DefaultDocumentStorage do
   @behaviour Absinthe.Subscription.DocumentStorage
-
   @moduledoc """
   Default document storage for Absinthe. Stores subscription
   documents and field keys in a Registry.
   """
 
-  @impl Absinthe.Subscription.DocumentStorage
-  def child_spec(opts) do
-    Registry.child_spec(opts)
-  end
+  alias Absinthe.Subscription
 
   @impl Absinthe.Subscription.DocumentStorage
-  def put(storage_process_name, doc_id, doc_value, field_keys) do
+  def put(pubsub, doc_id, doc_value, field_keys) do
+    registry = Subscription.registry_name(pubsub)
+
     pdict_add_fields(doc_id, field_keys)
 
     for field_key <- field_keys do
-      {:ok, _} = Registry.register(storage_process_name, field_key, doc_id)
+      {:ok, _} = Registry.register(registry, field_key, doc_id)
     end
 
-    {:ok, _} = Registry.register(storage_process_name, doc_id, doc_value)
+    {:ok, _} = Registry.register(registry, doc_id, doc_value)
   end
 
   @impl Absinthe.Subscription.DocumentStorage
-  def delete(storage_process_name, doc_id) do
+  def delete(pubsub, doc_id) do
+    registry = Subscription.registry_name(pubsub)
+
     for field_key <- pdict_fields(doc_id) do
-      Registry.unregister(storage_process_name, field_key)
+      Registry.unregister(registry, field_key)
     end
 
     pdict_delete_fields(doc_id)
 
-    Registry.unregister(storage_process_name, doc_id)
+    Registry.unregister(registry, doc_id)
 
     :ok
   end
 
   @impl Absinthe.Subscription.DocumentStorage
-  def get_docs_by_field_key(storage_process_name, field_key) do
-    storage_process_name
+  def get_docs_by_field_key(pubsub, field_key) do
+    registry = Subscription.registry_name(pubsub)
+
+    registry
     |> Registry.lookup(field_key)
     |> MapSet.new(fn {_pid, doc_id} -> doc_id end)
     |> Enum.reduce(%{}, fn doc_id, acc ->
-      case Registry.lookup(storage_process_name, doc_id) do
+      case Registry.lookup(registry, doc_id) do
         [] ->
           acc
 

--- a/lib/absinthe/subscription/default_document_storage.ex
+++ b/lib/absinthe/subscription/default_document_storage.ex
@@ -3,7 +3,7 @@ defmodule Absinthe.Subscription.DefaultDocumentStorage do
 
   @moduledoc """
   Default document storage for Absinthe. Stores subscription
-  documents and field keys in a Registry process.
+  documents and field keys in a Registry.
   """
 
   @impl Absinthe.Subscription.DocumentStorage

--- a/lib/absinthe/subscription/default_document_storage.ex
+++ b/lib/absinthe/subscription/default_document_storage.ex
@@ -12,33 +12,26 @@ defmodule Absinthe.Subscription.DefaultDocumentStorage do
   end
 
   @impl Absinthe.Subscription.DocumentStorage
-  def put(storage_process_name, doc_id, doc_value) do
-    {:ok, _} = Registry.register(storage_process_name, doc_id, doc_value)
-  end
-
-  @impl Absinthe.Subscription.DocumentStorage
-  def subscribe(storage_process_name, doc_id, field_keys) do
+  def put(storage_process_name, doc_id, doc_value, field_keys) do
     pdict_add_fields(doc_id, field_keys)
 
     for field_key <- field_keys do
       {:ok, _} = Registry.register(storage_process_name, field_key, doc_id)
     end
 
-    {:ok, field_keys}
+    {:ok, _} = Registry.register(storage_process_name, doc_id, doc_value)
   end
 
   @impl Absinthe.Subscription.DocumentStorage
   def delete(storage_process_name, doc_id) do
-    Registry.unregister(storage_process_name, doc_id)
-  end
-
-  @impl Absinthe.Subscription.DocumentStorage
-  def unsubscribe(storage_process_name, doc_id) do
     for field_key <- pdict_fields(doc_id) do
       Registry.unregister(storage_process_name, field_key)
     end
 
     pdict_delete_fields(doc_id)
+
+    Registry.unregister(storage_process_name, doc_id)
+
     :ok
   end
 

--- a/lib/absinthe/subscription/document_storage.ex
+++ b/lib/absinthe/subscription/document_storage.ex
@@ -4,7 +4,6 @@ defmodule Absinthe.Subscription.DocumentStorage do
   Absinthe how to store documents and the field keys subcribed to those
   documents.
   """
-  alias Module.Behaviour
 
   @doc """
   Child spec to determine how to start the

--- a/lib/absinthe/subscription/document_storage.ex
+++ b/lib/absinthe/subscription/document_storage.ex
@@ -1,0 +1,41 @@
+defmodule Absinthe.Subscription.DocumentStorage do
+  @moduledoc """
+  Behaviour for storing subscription documents. Used to tell
+  Absinthe how to store documents and the field keys subcribed to those
+  documents.
+  """
+  alias Module.Behaviour
+
+  @doc """
+  Child spec to determine how to start the
+  Document storage process
+  """
+  @callback child_spec(opts :: Keyword.t()) :: Supervisor.child_spec()
+
+  @doc """
+  Adds `doc` to storage with `doc_id` as the key if not already in storage. Also
+  associates each `{field, key}` pair in `field_keys` to the `doc_id`
+  """
+  @callback subscribe(
+              pubsub :: atom,
+              doc_id :: term,
+              doc :: %{
+                initial_phases: Absinthe.Subscription.PipelineSerializer.packed_pipeline(),
+                source: binary()
+              },
+              field_keys :: [{field :: term, key :: term}]
+            ) ::
+              {:ok, term} | {:error, :reason}
+
+  @doc """
+  Removes the document and field_keys associated with `doc_id` from
+  storage
+  """
+  @callback unsubscribe(pubsub :: atom, doc_id :: term) :: :ok
+
+  @doc """
+  Get all docs associated with the field_key
+  """
+  @callback get_docs_by_field_key(pubsub :: atom, field_key :: {field :: term, key :: term}) ::
+              map()
+end

--- a/lib/absinthe/subscription/document_storage.ex
+++ b/lib/absinthe/subscription/document_storage.ex
@@ -1,18 +1,20 @@
 defmodule Absinthe.Subscription.DocumentStorage do
   @moduledoc """
   Behaviour for storing subscription documents. Used to tell
-  Absinthe how to store documents and the field keys subcribed to those
+  Absinthe how to store documents and the field keys associated with those
   documents.
   """
 
   @doc """
   Child spec to determine how to start the
-  Document storage process
+  Document storage process. This will be supervised. Absinthe will give
+  the process a name and that name will be passed in the other callbacks
+  in order to reference it there.
   """
   @callback child_spec(opts :: Keyword.t()) :: Supervisor.child_spec()
 
   @doc """
-  Adds `doc` to storage with `doc_id` as the key if not already in storage.
+  Adds `doc` to storage with `doc_id` as the key.
   """
   @callback put(
               storage_process_name :: atom,
@@ -25,7 +27,7 @@ defmodule Absinthe.Subscription.DocumentStorage do
               {:ok, term} | {:error, :reason}
 
   @doc """
-  Associates each `{field, key}` pair in `field_keys` to the `doc_id`
+  Associates each `{field, key}` pair in `field_keys` to `doc_id`.
   """
   @callback subscribe(
               storage_process_name :: atom,
@@ -35,18 +37,17 @@ defmodule Absinthe.Subscription.DocumentStorage do
               {:ok, term} | {:error, :reason}
 
   @doc """
-  Removes the document
+  Removes the document.
   """
   @callback delete(storage_process_name :: atom, doc_id :: term) :: :ok
 
   @doc """
-  Removes the field_keys associated with `doc_id` from
-  storage
+  Removes the field_keys associated with `doc_id`.
   """
   @callback unsubscribe(storage_process_name :: atom, doc_id :: term) :: :ok
 
   @doc """
-  Get all docs associated with the field_key
+  Get all docs associated with `field_key`
   """
   @callback get_docs_by_field_key(
               storage_process_name :: atom,

--- a/lib/absinthe/subscription/document_storage.ex
+++ b/lib/absinthe/subscription/document_storage.ex
@@ -22,29 +22,15 @@ defmodule Absinthe.Subscription.DocumentStorage do
               doc :: %{
                 initial_phases: Absinthe.Subscription.PipelineSerializer.packed_pipeline(),
                 source: binary()
-              }
-            ) ::
-              {:ok, term} | {:error, :reason}
-
-  @doc """
-  Associates each `{field, key}` pair in `field_keys` to `doc_id`.
-  """
-  @callback subscribe(
-              storage_process_name :: atom,
-              doc_id :: term,
+              },
               field_keys :: [{field :: term, key :: term}]
             ) ::
               {:ok, term} | {:error, :reason}
 
   @doc """
-  Removes the document.
+  Removes the document. Along with any field_keys associated with it
   """
   @callback delete(storage_process_name :: atom, doc_id :: term) :: :ok
-
-  @doc """
-  Removes the field_keys associated with `doc_id`.
-  """
-  @callback unsubscribe(storage_process_name :: atom, doc_id :: term) :: :ok
 
   @doc """
   Get all docs associated with `field_key`

--- a/lib/absinthe/subscription/document_storage.ex
+++ b/lib/absinthe/subscription/document_storage.ex
@@ -3,6 +3,33 @@ defmodule Absinthe.Subscription.DocumentStorage do
   Behaviour for storing subscription documents. Used to tell
   Absinthe how to store documents and the field keys associated with those
   documents.
+
+  By default, Absinthe uses `Absinthe.Subscription.DefaultDocumentStorage` as
+  the storage for subscription documents. This behaviour can be implemented to
+  allow for a custom storage solution if needed.
+
+  The `child_spec` is used so that Absinthe can start your process when starting `Absinthe.Subscription`.
+
+  To tell `Absinthe.Subscription` to use your custom storage, make sure to pass in `document_storage` and `storage_opts`
+  when adding `Absinthe.Subscription` to your application supervisor.
+
+  ```elixir
+  {Absinthe.Subscription, pubsub: MyApp.Pubsub, document_storage: MyApp.DocumentStorage, storage_opts: [key1: value1, key2: value2]}
+  ```
+
+  Absinthe.Subscription will update `storage_opts` to include a `name` key. This will be the name `Absinthe.Subscription` uses to
+  reference the process.
+
+  ```elixir
+  @impl Absinthe.Subscription.DocumentStorage
+  def child_spec(opts) do
+    # opts is the `storage_opts` with the `name` key added
+    {
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]}
+    }
+  end
+  ```
   """
 
   alias Absinthe.Subscription

--- a/lib/absinthe/subscription/document_storage.ex
+++ b/lib/absinthe/subscription/document_storage.ex
@@ -12,29 +12,45 @@ defmodule Absinthe.Subscription.DocumentStorage do
   @callback child_spec(opts :: Keyword.t()) :: Supervisor.child_spec()
 
   @doc """
-  Adds `doc` to storage with `doc_id` as the key if not already in storage. Also
-  associates each `{field, key}` pair in `field_keys` to the `doc_id`
+  Adds `doc` to storage with `doc_id` as the key if not already in storage.
   """
-  @callback subscribe(
-              pubsub :: atom,
+  @callback put(
+              storage_process_name :: atom,
               doc_id :: term,
               doc :: %{
                 initial_phases: Absinthe.Subscription.PipelineSerializer.packed_pipeline(),
                 source: binary()
-              },
+              }
+            ) ::
+              {:ok, term} | {:error, :reason}
+
+  @doc """
+  Associates each `{field, key}` pair in `field_keys` to the `doc_id`
+  """
+  @callback subscribe(
+              storage_process_name :: atom,
+              doc_id :: term,
               field_keys :: [{field :: term, key :: term}]
             ) ::
               {:ok, term} | {:error, :reason}
 
   @doc """
-  Removes the document and field_keys associated with `doc_id` from
+  Removes the document
+  """
+  @callback delete(storage_process_name :: atom, doc_id :: term) :: :ok
+
+  @doc """
+  Removes the field_keys associated with `doc_id` from
   storage
   """
-  @callback unsubscribe(pubsub :: atom, doc_id :: term) :: :ok
+  @callback unsubscribe(storage_process_name :: atom, doc_id :: term) :: :ok
 
   @doc """
   Get all docs associated with the field_key
   """
-  @callback get_docs_by_field_key(pubsub :: atom, field_key :: {field :: term, key :: term}) ::
+  @callback get_docs_by_field_key(
+              storage_process_name :: atom,
+              field_key :: {field :: term, key :: term}
+            ) ::
               map()
 end

--- a/lib/absinthe/subscription/document_storage.ex
+++ b/lib/absinthe/subscription/document_storage.ex
@@ -14,7 +14,8 @@ defmodule Absinthe.Subscription.DocumentStorage do
   @callback child_spec(opts :: Keyword.t()) :: Supervisor.child_spec()
 
   @doc """
-  Adds `doc` to storage with `doc_id` as the key.
+  Adds `doc` to storage with `doc_id` as the key. Associates the given
+  `field_keys` with `doc_id`.
   """
   @callback put(
               storage_process_name :: atom,

--- a/lib/absinthe/subscription/document_storage.ex
+++ b/lib/absinthe/subscription/document_storage.ex
@@ -5,6 +5,9 @@ defmodule Absinthe.Subscription.DocumentStorage do
   documents.
   """
 
+  alias Absinthe.Subscription
+  alias Absinthe.Subscription.PipelineSerializer
+
   @doc """
   Child spec to determine how to start the
   Document storage process. This will be supervised. Absinthe will give
@@ -41,4 +44,94 @@ defmodule Absinthe.Subscription.DocumentStorage do
               field_key :: {field :: term, key :: term}
             ) ::
               map()
+
+  @doc false
+  def put(pubsub, doc_id, doc, field_keys) do
+    {storage_module, storage_process_name} = storage_info(pubsub)
+
+    :telemetry.span(
+      [:absinthe, :subscription, :storage, :put],
+      %{
+        doc_id: doc_id,
+        doc: doc,
+        field_keys: field_keys,
+        storage_module: storage_module
+      },
+      fn ->
+        field_keys = List.wrap(field_keys)
+
+        doc_value = %{
+          initial_phases: PipelineSerializer.pack(doc.initial_phases),
+          source: doc.source
+        }
+
+        result = storage_module.put(storage_process_name, doc_id, doc_value, field_keys)
+
+        {result,
+         %{
+           doc_id: doc_id,
+           doc: doc,
+           field_keys: field_keys,
+           storage_module: storage_module
+         }}
+      end
+    )
+  end
+
+  @doc false
+  def delete(pubsub, doc_id) do
+    {storage_module, storage_process_name} = storage_info(pubsub)
+
+    :telemetry.span(
+      [:absinthe, :subscription, :storage, :delete],
+      %{
+        doc_id: doc_id,
+        storage_module: storage_module
+      },
+      fn ->
+        result = storage_module.delete(storage_process_name, doc_id)
+
+        {result,
+         %{
+           doc_id: doc_id,
+           storage_module: storage_module
+         }}
+      end
+    )
+  end
+
+  @doc false
+  def get_docs_by_field_key(pubsub, field_key) do
+    {storage_module, storage_process_name} = storage_info(pubsub)
+
+    :telemetry.span(
+      [:absinthe, :subscription, :storage, :get_docs_by_field_key],
+      %{
+        field_key: field_key,
+        storage_module: storage_module
+      },
+      fn ->
+        result =
+          storage_process_name
+          |> storage_module.get_docs_by_field_key(field_key)
+          |> Enum.map(fn {doc_id, %{initial_phases: initial_phases} = doc} ->
+            initial_phases = PipelineSerializer.unpack(initial_phases)
+            {doc_id, Map.put(doc, :initial_phases, initial_phases)}
+          end)
+          |> Map.new()
+
+        {result,
+         %{
+           field_key: field_key,
+           storage_module: storage_module
+         }}
+      end
+    )
+  end
+
+  defp storage_info(pubsub) do
+    storage_module = Subscription.document_storage(pubsub)
+    storage_process_name = Subscription.document_storage_name(pubsub)
+    {storage_module, storage_process_name}
+  end
 end

--- a/lib/absinthe/subscription/supervisor.ex
+++ b/lib/absinthe/subscription/supervisor.ex
@@ -37,8 +37,7 @@ defmodule Absinthe.Subscription.Supervisor do
           ]
 
         _ ->
-          opts
-          |> Keyword.get(opts, :storage_opts, Keyword.new())
+          Keyword.get(opts, :storage_opts, Keyword.new())
       end
 
     Supervisor.start_link(

--- a/mix.exs
+++ b/mix.exs
@@ -184,7 +184,8 @@ defmodule Absinthe.Mixfile do
         Absinthe.Subscription,
         Absinthe.Subscription.Pubsub,
         Absinthe.Subscription.Local,
-        Absinthe.Subscription.PipelineSerializer
+        Absinthe.Subscription.PipelineSerializer,
+        Absinthe.Subscription.DocumentStorage
       ],
       Extensibility: [
         Absinthe.Pipeline,

--- a/test/absinthe/subscription/document_storage_test.exs
+++ b/test/absinthe/subscription/document_storage_test.exs
@@ -1,0 +1,373 @@
+defmodule Absinthe.Subscription.DocumentStorageTest do
+  use Absinthe.Case
+
+  defmodule TestDocumentStorageSchema do
+    use Absinthe.Schema
+
+    query do
+      field :foo, :string
+    end
+
+    object :user do
+      field :id, :id
+      field :name, :string
+
+      field :group, :group do
+        resolve fn user, _, %{context: %{test_pid: pid}} ->
+          batch({__MODULE__, :batch_get_group, pid}, nil, fn _results ->
+            {:ok, user.group}
+          end)
+        end
+      end
+    end
+
+    object :group do
+      field :name, :string
+    end
+
+    def batch_get_group(test_pid, _) do
+      # send a message to the test process every time we access this function.
+      # if batching is working properly, it should only happen once.
+      send(test_pid, :batch_get_group)
+      %{}
+    end
+
+    subscription do
+      field :raises, :string do
+        config fn _, _ ->
+          {:ok, topic: "*"}
+        end
+
+        resolve fn _, _, _ ->
+          raise "boom"
+        end
+      end
+
+      field :user, :user do
+        arg :id, :id
+
+        config fn args, _ ->
+          {:ok, topic: args[:id] || "*"}
+        end
+
+        trigger :update_user,
+          topic: fn user ->
+            [user.id, "*"]
+          end
+      end
+
+      field :thing, :string do
+        arg :client_id, non_null(:id)
+
+        config fn
+          _args, %{context: %{authorized: false}} ->
+            {:error, "unauthorized"}
+
+          args, _ ->
+            {
+              :ok,
+              topic: args.client_id
+            }
+        end
+      end
+
+      field :multiple_topics, :string do
+        config fn _, _ ->
+          {:ok, topic: ["topic_1", "topic_2", "topic_3"]}
+        end
+      end
+
+      field :other_user, :user do
+        arg :id, :id
+
+        config fn
+          args, %{context: %{context_id: context_id, document_id: document_id}} ->
+            {:ok, topic: args[:id] || "*", context_id: context_id, document_id: document_id}
+
+          args, %{context: %{context_id: context_id}} ->
+            {:ok, topic: args[:id] || "*", context_id: context_id}
+        end
+      end
+
+      field :relies_on_document, :string do
+        config fn _, %{document: %Absinthe.Blueprint{} = document} ->
+          %{type: :subscription, name: op_name} = Absinthe.Blueprint.current_operation(document)
+          {:ok, topic: "*", context_id: "*", document_id: op_name}
+        end
+      end
+    end
+
+    mutation do
+      field :update_user, :user do
+        arg :id, non_null(:id)
+
+        resolve fn _, %{id: id}, _ ->
+          {:ok, %{id: id, name: "foo"}}
+        end
+      end
+    end
+  end
+
+  defmodule TestDocumentStoragePubSub do
+    @behaviour Absinthe.Subscription.Pubsub
+
+    def start_link() do
+      Registry.start_link(keys: :duplicate, name: __MODULE__)
+    end
+
+    def node_name() do
+      node()
+    end
+
+    def subscribe(topic) do
+      Registry.register(__MODULE__, topic, [])
+      :ok
+    end
+
+    def publish_subscription(topic, data) do
+      message = %{
+        topic: topic,
+        event: "subscription:data",
+        result: data
+      }
+
+      Registry.dispatch(__MODULE__, topic, fn entries ->
+        for {pid, _} <- entries, do: send(pid, {:broadcast, message})
+      end)
+    end
+
+    def publish_mutation(_proxy_topic, _mutation_result, _subscribed_fields) do
+      # this pubsub is local and doesn't support clusters
+      :ok
+    end
+  end
+
+  defmodule TestDocumentStorage do
+    @behaviour Absinthe.Subscription.DocumentStorage
+    use GenServer
+
+    def start_link(_) do
+      GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+    end
+
+    @impl GenServer
+    def init(_) do
+      {:ok, %{docs: %{}, field_keys: %{}}}
+    end
+
+    @impl GenServer
+    def handle_cast({:put, doc_id, doc_value, field_keys}, %{
+          docs: docs,
+          field_keys: field_keys_map
+        }) do
+      docs = Map.put_new(docs, doc_id, doc_value)
+
+      field_keys_map =
+        Enum.reduce(field_keys, field_keys_map, fn field_key, field_keys_map ->
+          Map.update(field_keys_map, field_key, [doc_id], fn doc_ids -> [doc_id | doc_ids] end)
+        end)
+
+      {:noreply, %{docs: docs, field_keys: field_keys_map}}
+    end
+
+    @impl GenServer
+    def handle_cast({:delete, doc_id}, %{
+          docs: docs,
+          field_keys: field_keys_map
+        }) do
+      docs = Map.delete(docs, doc_id)
+
+      field_keys_map =
+        Enum.map(field_keys_map, fn {field_key, doc_ids} ->
+          doc_ids = List.delete(doc_ids, doc_id)
+          {field_key, doc_ids}
+        end)
+        |> Map.new()
+
+      {:noreply, %{docs: docs, field_keys: field_keys_map}}
+    end
+
+    @impl GenServer
+    def handle_call(
+          {:get_docs_by_field_key, field_key},
+          _from,
+          %{
+            docs: docs,
+            field_keys: field_keys_map
+          } = state
+        ) do
+      doc_ids = Map.get(field_keys_map, field_key, [])
+
+      docs_to_return =
+        docs
+        |> Enum.filter(fn {doc_id, _} -> doc_id in doc_ids end)
+        |> Map.new()
+
+      {:reply, docs_to_return, state}
+    end
+
+    @impl Absinthe.Subscription.DocumentStorage
+    def put(_pubsub, doc_id, doc_value, field_keys) do
+      GenServer.cast(__MODULE__, {:put, doc_id, doc_value, field_keys})
+      :ok
+    end
+
+    @impl Absinthe.Subscription.DocumentStorage
+    def delete(_pubsub, doc_id) do
+      GenServer.cast(__MODULE__, {:delete, doc_id})
+
+      :ok
+    end
+
+    @impl Absinthe.Subscription.DocumentStorage
+    def get_docs_by_field_key(_pubsub, field_key) do
+      GenServer.call(__MODULE__, {:get_docs_by_field_key, field_key})
+    end
+  end
+
+  def run_subscription(query, schema, opts \\ []) do
+    opts =
+      Keyword.update(
+        opts,
+        :context,
+        %{pubsub: TestDocumentStoragePubSub},
+        &Map.put(&1, :pubsub, opts[:context][:pubsub] || TestDocumentStoragePubSub)
+      )
+
+    case run(query, schema, opts) do
+      {:ok, %{"subscribed" => topic}} = val ->
+        opts[:context][:pubsub].subscribe(topic)
+        val
+
+      val ->
+        val
+    end
+  end
+
+  setup do
+    start_supervised(TestDocumentStorage)
+
+    start_supervised(%{
+      id: TestDocumentStoragePubSub,
+      start: {TestDocumentStoragePubSub, :start_link, []}
+    })
+
+    start_supervised(
+      {Absinthe.Subscription, pubsub: TestDocumentStoragePubSub, storage: TestDocumentStorage}
+    )
+
+    :ok
+  end
+
+  @query """
+  subscription ($clientId: ID!) {
+    thing(clientId: $clientId)
+  }
+  """
+  test "can subscribe the current process" do
+    client_id = "abc"
+
+    assert {:ok, %{"subscribed" => topic}} =
+             run_subscription(
+               @query,
+               TestDocumentStorageSchema,
+               variables: %{"clientId" => client_id},
+               context: %{pubsub: TestDocumentStoragePubSub}
+             )
+
+    Absinthe.Subscription.publish(TestDocumentStoragePubSub, "foo", thing: client_id)
+
+    assert_receive({:broadcast, msg})
+
+    assert %{
+             event: "subscription:data",
+             result: %{data: %{"thing" => "foo"}},
+             topic: topic
+           } == msg
+  end
+
+  @query """
+  subscription ($clientId: ID!) {
+    thing(clientId: $clientId)
+  }
+  """
+  test "can unsubscribe the current process" do
+    client_id = "abc"
+
+    assert {:ok, %{"subscribed" => topic}} =
+             run_subscription(
+               @query,
+               TestDocumentStorageSchema,
+               variables: %{"clientId" => client_id},
+               context: %{pubsub: TestDocumentStoragePubSub}
+             )
+
+    Absinthe.Subscription.unsubscribe(TestDocumentStoragePubSub, topic)
+
+    Absinthe.Subscription.publish(TestDocumentStoragePubSub, "foo", thing: client_id)
+
+    refute_receive({:broadcast, _})
+  end
+
+  @query """
+  subscription {
+    multipleTopics
+  }
+  """
+  test "schema can provide multiple topics to subscribe to" do
+    assert {:ok, %{"subscribed" => topic}} =
+             run_subscription(
+               @query,
+               TestDocumentStorageSchema,
+               variables: %{},
+               context: %{pubsub: TestDocumentStoragePubSub}
+             )
+
+    msg = %{
+      event: "subscription:data",
+      result: %{data: %{"multipleTopics" => "foo"}},
+      topic: topic
+    }
+
+    Absinthe.Subscription.publish(TestDocumentStoragePubSub, "foo", multiple_topics: "topic_1")
+
+    assert_receive({:broadcast, ^msg})
+
+    Absinthe.Subscription.publish(TestDocumentStoragePubSub, "foo", multiple_topics: "topic_2")
+
+    assert_receive({:broadcast, ^msg})
+
+    Absinthe.Subscription.publish(TestDocumentStoragePubSub, "foo", multiple_topics: "topic_3")
+
+    assert_receive({:broadcast, ^msg})
+  end
+
+  @query """
+  subscription {
+    multipleTopics
+  }
+  """
+  test "unsubscription works when multiple topics are provided" do
+    assert {:ok, %{"subscribed" => topic}} =
+             run_subscription(
+               @query,
+               TestDocumentStorageSchema,
+               variables: %{},
+               context: %{pubsub: TestDocumentStoragePubSub}
+             )
+
+    Absinthe.Subscription.unsubscribe(TestDocumentStoragePubSub, topic)
+
+    Absinthe.Subscription.publish(TestDocumentStoragePubSub, "foo", multiple_topics: "topic_1")
+
+    refute_receive({:broadcast, _})
+
+    Absinthe.Subscription.publish(TestDocumentStoragePubSub, "foo", multiple_topics: "topic_2")
+
+    refute_receive({:broadcast, _})
+
+    Absinthe.Subscription.publish(TestDocumentStoragePubSub, "foo", multiple_topics: "topic_3")
+
+    refute_receive({:broadcast, _})
+  end
+end


### PR DESCRIPTION
* Create a behaviour named `Absinthe.Subscription.DocumentStorage` to allow customization around how Absinthe stores subscription documents and field key pairs. 
* Create an implementation named, `Absinthe.Subscription.DefaultDocumentStorage` implemented using the Registry and algorithms Absinthe used previously
* Update `Absinthe.Subscription.Supervisor` to check for a `storage` key in its `opts`. The default value is `Absinthe.Subscription.DefaultDocumentStorage`
* Update `Absinthe.Subscription` to use the configured storage module