### PR TITLE
[GRAPH-1099] Allows config error to return a map

### DIFF
--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -109,6 +109,15 @@ defmodule Absinthe.Phase.Document.Result do
   defp field_name(%{alias: name}), do: name
   defp field_name(%{name: name}), do: name
 
+  defp format_error(%Phase.Error{message: %{message: _message} = error_object} = error, _opts) do
+    if Enum.empty?(error.locations) do
+      error_object
+    else
+      locations = Enum.flat_map(error.locations, &format_location/1)
+      Map.put_new(error_object, :locations, locations)
+    end
+  end
+
   defp format_error(%Phase.Error{locations: []} = error, opts) do
     error_object = %{message: error.message}
 

--- a/lib/absinthe/phase/subscription/subscribe_self.ex
+++ b/lib/absinthe/phase/subscription/subscribe_self.ex
@@ -75,23 +75,29 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
         {:ok, config}
 
       {:error, msg} ->
-        error = %Phase.Error{
-          phase: __MODULE__,
-          message: msg,
-          locations: [field.source_location]
-        }
+        {:error, create_config_error(field, msg)}
 
-        {:error, error}
+      {:error, msg, extra} ->
+        {:error, create_config_error(field, msg, extra)}
 
       val ->
         raise """
         Invalid return from config function!
 
-        A config function must return `{:ok, config}` or `{:error, msg}`. You returned:
+        A config function must return `{:ok, config}`, `{:error, msg}` or `{:error, msg, extra}`. You returned:
 
         #{inspect(val)}
         """
     end
+  end
+
+  defp create_config_error(field, msg, extra \\ %{}) do
+    %Phase.Error{
+      phase: __MODULE__,
+      message: msg,
+      locations: [field.source_location],
+      extra: extra
+    }
   end
 
   defp get_field_keys(%{schema_node: schema_node} = _field, config) do

--- a/lib/absinthe/phase/subscription/subscribe_self.ex
+++ b/lib/absinthe/phase/subscription/subscribe_self.ex
@@ -75,29 +75,23 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
         {:ok, config}
 
       {:error, msg} ->
-        {:error, create_config_error(field, msg)}
+        error = %Phase.Error{
+          phase: __MODULE__,
+          message: msg,
+          locations: [field.source_location]
+        }
 
-      {:error, msg, extra} ->
-        {:error, create_config_error(field, msg, extra)}
+        {:error, error}
 
       val ->
         raise """
         Invalid return from config function!
 
-        A config function must return `{:ok, config}`, `{:error, msg}` or `{:error, msg, extra}`. You returned:
+        A config function must return `{:ok, config}` or `{:error, msg}`. You returned:
 
         #{inspect(val)}
         """
     end
-  end
-
-  defp create_config_error(field, msg, extra \\ %{}) do
-    %Phase.Error{
-      phase: __MODULE__,
-      message: msg,
-      locations: [field.source_location],
-      extra: extra
-    }
   end
 
   defp get_field_keys(%{schema_node: schema_node} = _field, config) do

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -221,9 +221,9 @@ defmodule Absinthe.Execution.SubscriptionTest do
         end
       end
 
-      field :config_error_with_extra, :string do
+      field :config_error_with_map, :string do
         config fn _, _ ->
-          {:error, "failed", %{code: "FAILED"}}
+          {:error, %{message: "failed", extensions: %{code: "FAILED"}}}
         end
       end
     end
@@ -613,27 +613,16 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
   @query """
   subscription Example {
-    configErrorWithExtra
+    configErrorWithMap
   }
   """
-  test "config errors with extra" do
-    assert {:ok, %{errors: [%{message: "failed", code: "FAILED"}]}} =
-             run_subscription(
-               @query,
-               Schema,
-               variables: %{},
-               context: %{pubsub: PubSub}
-             )
-  end
-
-  test "config errors with extra and spec_compliant_errors turned on" do
+  test "config errors with a map" do
     assert {:ok, %{errors: [%{message: "failed", extensions: %{code: "FAILED"}}]}} =
              run_subscription(
                @query,
                Schema,
                variables: %{},
-               context: %{pubsub: PubSub},
-               spec_compliant_errors: true
+               context: %{pubsub: PubSub}
              )
   end
 

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -214,6 +214,18 @@ defmodule Absinthe.Execution.SubscriptionTest do
           {:ok, topic: "*", context_id: "*", document_id: op_name}
         end
       end
+
+      field :config_error, :string do
+        config fn _, _ ->
+          {:error, "failed"}
+        end
+      end
+
+      field :config_error_with_extra, :string do
+        config fn _, _ ->
+          {:error, "failed", %{code: "FAILED"}}
+        end
+      end
     end
 
     mutation do
@@ -582,6 +594,47 @@ defmodule Absinthe.Execution.SubscriptionTest do
     # we should get this twice since the different contexts prevent batching.
     assert_receive(:batch_get_group)
     assert_receive(:batch_get_group)
+  end
+
+  @query """
+  subscription Example {
+    configError
+  }
+  """
+  test "config errors" do
+    assert {:ok, %{errors: [%{message: "failed"}]}} =
+             run_subscription(
+               @query,
+               Schema,
+               variables: %{},
+               context: %{pubsub: PubSub}
+             )
+  end
+
+  @query """
+  subscription Example {
+    configErrorWithExtra
+  }
+  """
+  test "config errors with extra" do
+    assert {:ok, %{errors: [%{message: "failed", code: "FAILED"}]}} =
+             run_subscription(
+               @query,
+               Schema,
+               variables: %{},
+               context: %{pubsub: PubSub}
+             )
+  end
+
+  test "config errors with extra and spec_compliant_errors turned on" do
+    assert {:ok, %{errors: [%{message: "failed", extensions: %{code: "FAILED"}}]}} =
+             run_subscription(
+               @query,
+               Schema,
+               variables: %{},
+               context: %{pubsub: PubSub},
+               spec_compliant_errors: true
+             )
   end
 
   describe "subscription_ids" do


### PR DESCRIPTION
This PR makes it so that if `config/2` returns an error tuple where the second element is a map, then that map is treated as the error response.

Subscription config errors currently expect a tuple of `{:error, msg }`. If message is an map, when returned to the user, it looks like:

```json
"errors": [
    {"message": {"extensions": {"code": "BAD_REQUEST"}, "message": "Invalid argument"}}
]
```

This causes trouble for us as we return spec compliant errors and they get wrapped in the message.

This PR makes it so returning the following from `config/2`

```elixir
{:error, %{message: "Invalid argument", extensions: %{code: "BAD_REQUEST"}}
```

Will return 

```json
"errors": [
    {"extensions": {"code": "BAD_REQUEST"}, "message": "Invalid argument"}
]
```

